### PR TITLE
Ensure application is built with the same glibc version as the runtime environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM docker.io/rust:1.89 as builder
+FROM docker.io/rust:1.89-trixie as builder
 WORKDIR /usr/src/jetbrains-fls-exporter
 COPY Cargo.toml .
 COPY Cargo.lock .
 COPY src src
 RUN cargo install --path .
 
-FROM docker.io/debian:bookworm-slim
+FROM docker.io/debian:trixie-slim
 RUN apt-get update && apt-get install -y ca-certificates openssl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/jetbrains-fls-exporter /usr/local/bin/jetbrains-fls-exporter
 CMD ["jetbrains-fls-exporter"]


### PR DESCRIPTION
This change addresses a runtime error caused by a mismatch in glibc versions between the build and runtime containers. Specifically, the following error was encountered when starting the container:

```
jetbrains-fls-exporter: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by jetbrains-fls-exporter)
```

The issue was introduced when the Rust container used for building the exporter was updated from version `1.87` to `1.89`. This update changed the base OS from **Debian Bookworm** (glibc 2.36) to **Debian Trixie** (glibc 2.41). However, the runtime container remained based on `docker.io/debian:bookworm-slim`, which does not provide the required glibc version.

To resolve this, the build process now uses the same OS version as the runtime container, ensuring that the compiled binary is compatible with the available glibc version at runtime. 